### PR TITLE
Fix metadata render

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -87,7 +87,7 @@ class syntax_plugin_imagebox extends DokuWiki_Syntax_Plugin {
 
 					// Use dokuwiki image metadata renderer
 					if(media_isexternal($src)) {
-						$renderer->internalmedia($src, $match['title']);
+						$renderer->externalmedia($src, $match['title']);
 					} else {
 						resolve_mediaid(getNS($ID), $src, $exists);
 						$renderer->internalmedia($src, $match['title']);

--- a/syntax.php
+++ b/syntax.php
@@ -78,19 +78,28 @@ class syntax_plugin_imagebox extends DokuWiki_Syntax_Plugin {
 
 	function render($mode, Doku_Renderer $renderer, $data){
 
-		global $ID;
-                if($mode == 'metadata'){
-			list($state,$match) = $data;
+        if($mode == 'metadata'){
+			list($state, $match) = $data;
 
 			switch($state){
 				case DOKU_LEXER_ENTER:
-                                    list ($src) = explode('#', $match['src'], 2);
-                                    if(media_isexternal($src)) return;
-                                    resolve_mediaid(getNS($ID), $src, $exists);
-                                    $renderer->meta['relation']['media'][$src] = $exists;
-                                    $renderer->persistent['relation']['media'][$src] = $exists;
-                        }
-                }
+					list ($src) = explode('#', $match['src'], 2);
+
+					// Use dokuwiki image metadata renderer
+					if(media_isexternal($src)) {
+						$renderer->internalmedia($src, $match['title']);
+					} else {
+						resolve_mediaid(getNS($ID), $src, $exists);
+						$renderer->internalmedia($src, $match['title']);
+
+						// Clear previous persistent data
+						if (isset($renderer->persistent['relation']['media'][$src])) {
+							unset($renderer->persistent['relation']['media'][$src]);
+						}
+					}
+
+            }
+        }
 
 
 		if($mode == 'xhtml'){

--- a/syntax.php
+++ b/syntax.php
@@ -77,6 +77,7 @@ class syntax_plugin_imagebox extends DokuWiki_Syntax_Plugin {
 	}
 
 	function render($mode, Doku_Renderer $renderer, $data){
+		global $ID
 
         if($mode == 'metadata'){
 			list($state, $match) = $data;


### PR DESCRIPTION
This changes two problems for metadata rendering.

  * Use Dokuwiki's metadata renderer. This will ensure all metadata to be inserted correctly, like 'firstimage'.
  * Clear previous persistent data. (Relation info should not saved to persistent, but only in current metadata as I know.)